### PR TITLE
Added a Guitars About Page using PF4 About Modal

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class UserController < ApplicationController
-  def index
-    render json: %w[
-      admin guest
-    ]
-  end
-end

--- a/app/javascript/components/GuitarInfo.js
+++ b/app/javascript/components/GuitarInfo.js
@@ -11,14 +11,31 @@ import {
   CardFooter,
   Button,
   Modal,
+  AboutModal,
   ModalVariant,
   Form,
   FormGroup,
-  TextInput
+  TextInput,
+  TextContent,
+  TextList,
+  TextListItem
 } from '@patternfly/react-core';
 import { getGuitarUrlWithId } from './constants.js';
+import { logoUrl } from './constants.js';
 
 const GuitarInfo = ({ id, name, url, price, description, getGuitars }) => {
+  // About Modal
+  const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
+
+  const openAboutModal = () => {
+    setIsAboutModalOpen(true);
+  };
+
+  const closeAboutModal = () => {
+    setIsAboutModalOpen(false);
+  };
+
+  // Form Modal
   const [isFormModalOpen, setIsFormModalOpen] = useState(false);
 
   const openFormModal = () => {
@@ -73,11 +90,11 @@ const GuitarInfo = ({ id, name, url, price, description, getGuitars }) => {
           </GridItem>
           <GridItem>
             <CardTitle>{name}</CardTitle>
-            <CardBody>
-              Price: {price} <br />
-              Description: {description}
-            </CardBody>
+            <CardBody>Price: {price}</CardBody>
             <CardFooter>
+              <Button variant="primary" role="about-modal-button" onClick={openAboutModal}>
+                Check me out
+              </Button>
               <Button variant="secondary" onClick={openFormModal}>
                 Edit
               </Button>
@@ -148,6 +165,28 @@ const GuitarInfo = ({ id, name, url, price, description, getGuitars }) => {
             </FormGroup>
           </Form>
         </Modal>
+      )}
+
+      {isAboutModalOpen && (
+        <AboutModal
+          isOpen={isAboutModalOpen}
+          onClose={closeAboutModal}
+          trademark="Trademark and stuff"
+          brandImageSrc={logoUrl}
+          brandImageAlt="Guitar Image"
+          productName={name}
+          backgroundImageSrc={url}>
+          <TextContent>
+            <TextList component="dl">
+              <TextListItem component="dt">Name: </TextListItem>
+              <TextListItem component="dd">{name}</TextListItem>
+              <TextListItem component="dt">Description: </TextListItem>
+              <TextListItem component="dd">{description}</TextListItem>
+              <TextListItem component="dt">Price: </TextListItem>
+              <TextListItem component="dd">{price}</TextListItem>
+            </TextList>
+          </TextContent>
+        </AboutModal>
       )}
     </GalleryItem>
   );

--- a/app/javascript/components/constants.js
+++ b/app/javascript/components/constants.js
@@ -3,3 +3,5 @@ export const GUITARS_URL = '/guitars';
 export const getGuitarUrlWithId = (id) => {
   return GUITARS_URL + `/${id}`;
 };
+export const logoUrl =
+  'https://store.playstation.com/store/api/chihiro/00_09_000/container/US/en/99/UP8802-CUSA02084_00-AV00000000000013/0/image?_version=00_09_000&platform=chihiro&bg_color=000000&opacity=100&w=360&h=360';

--- a/app/javascript/components/tests/GuitarGallery.test.js
+++ b/app/javascript/components/tests/GuitarGallery.test.js
@@ -1,12 +1,18 @@
 import React from 'react';
-import { waitFor, render, screen } from '@testing-library/react';
+import { waitFor, render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import axios from 'axios';
+
 import GuitarGallery from '../GuitarGallery.js';
+
 import { GUITARS_URL } from '../constants';
 import { guitarData } from './fixtures';
 
-test('rendering the GuitarGallery component and asserting for test mock data to be in the page', async () => {
+test('expect true to be true, always start on the right foot :)', async () => {
+  expect(true).toBe(true);
+});
+
+test('Loading the data from the server and presenting it to the screen', async () => {
   await axios.get.mockResolvedValueOnce(guitarData);
   const { unmount, getByText } = render(<GuitarGallery key={1} />);
 
@@ -37,6 +43,43 @@ test('rendering the GuitarGallery component and asserting for test mock data to 
   const anotherElementContainingPrice = screen.getByText(/200/);
   expect(anotherElementContainingPrice).toBeInTheDocument();
   expect(anotherElementContainingPrice).toHaveTextContent(/Price/i);
+  await waitFor(() => screen.getByText('guitar1_test'));
+
+  expect(screen.getByText('guitar1_test')).toBeInTheDocument();
+  expect(screen.getByText('guitar2_test')).toBeInTheDocument();
+
+  // unmnount the component from the DOM
+  unmount();
+});
+
+test('AboutModal opens on click', async () => {
+  await axios.get.mockResolvedValueOnce(guitarData);
+  const { unmount } = render(<GuitarGallery />);
+
+  // wait for the component to load:
+  await waitFor(() => screen.getAllByText('Check me out'));
+  // assign the first element of the array to button and test it:
+  const button = screen.getAllByText('Check me out').shift();
+  console.log(button);
+  expect(button).toBeInTheDocument();
+  expect(button).not.toBeDisabled();
+
+  // Q: no need to wait again?
+  // Another way to test it, using getAllByRole:
+
+  // const button2 = screen.getAllByRole('about-modal-button').shift();
+  // const button2 = screen.getAllByRole('about-modal-button', { name: 'Check me out' });
+  // console.log(button2);
+  // expect(button2).not.toBeDisabled();
+
+  // click on the button to open the AboutModal:
+  fireEvent.click(button);
+  // OR:
+  // await userEvent.click(screen.getByText('Load Greeting'));
+
+  // wait for the AboutModal to open:
+  await waitFor(() => screen.findByText('Trademark and stuff'));
+  expect(screen.getByText('Trademark and stuff')).toBeInTheDocument();
 
   // unmnount the component from the DOM
   unmount();

--- a/app/javascript/components/tests/GuitarInfo.test.js
+++ b/app/javascript/components/tests/GuitarInfo.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { waitFor, render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import GuitarInfo from '../GuitarInfo.js';
+import { guitarPropsToRender } from './fixtures';
+
+test('AboutModal Render & Functionality', async () => {
+  const getGuitars = jest.fn();
+  const { unmount } = render(<GuitarInfo {...guitarPropsToRender} getGuitars={getGuitars} />);
+
+  // wait for the component to load:
+  await waitFor(() => screen.getByText('Check me out'));
+
+  const checkMeOutButton = screen.getByText('Check me out');
+  expect(checkMeOutButton).not.toBeDisabled();
+
+  // click on the button to open the AboutModal:
+  fireEvent.click(checkMeOutButton);
+
+  // wait for the AboutModal to open:
+  await waitFor(() => screen.getByText('Trademark and stuff'));
+  expect(screen.getByText('Trademark and stuff')).toBeInTheDocument();
+  expect(screen.getByText(/Name:/i)).toBeInTheDocument();
+  expect(screen.getByText(/Description:/i)).toBeInTheDocument();
+
+  // Ensure the correct data is presented in the AboutModal:
+  expect(screen.getByText(/some description in guitar1_test/i)).toBeInTheDocument();
+  expect(screen.getByText('100')).toBeInTheDocument();
+
+  // close the AboutModal:
+  const closeAboutModalButton = screen.getByLabelText('Close Dialog');
+  fireEvent.click(closeAboutModalButton);
+
+  // wait for the AboutModal to close:
+  await waitFor(() => expect(screen.queryByText('Trademark and stuff')).not.toBeInTheDocument());
+
+  expect(getGuitars).toHaveBeenCalledTimes(0);
+
+  // unmnount the component from the DOM
+  unmount();
+});

--- a/app/javascript/components/tests/fixtures.js
+++ b/app/javascript/components/tests/fixtures.js
@@ -16,3 +16,12 @@ export const guitarData = {
     }
   ]
 };
+
+// For the GuitarInfo testing:
+export const guitarPropsToRender = {
+  id: 1,
+  name: 'guitar1_test',
+  url: 'https://rukminim1.flixcart.com/image/416/416/acoustic-guitar/x/8/w/topaz-blue-signature-original-imaefec7uhypjdr9.jpeg?q=70',
+  price: 100,
+  description: 'some description in guitar1_test'
+};


### PR DESCRIPTION
This PR adds functionality to present a single guitar in a [PatternFly 4 About Modal](https://www.patternfly.org/v4/components/about-modal/), alongside with more information regarding the guitar
In this Modal, the guitar is presented with a bigger picture & with it's description

- [x] Adding appropriate screenshots
- [x] Rebase after merge of #8 
- [x] Rebase after merge of #32 
- [x] Rebase after merge of #35  
- [x] Add appropriate tests for the aboutModal (GuitarInfo.test.js)

Screenshots:

Clicking the 'Check Me Out' button on the first guitar on the left in the top row
![Clicking the 'Check Me Out' button on the first guitar on the left in the top row](https://github.com/LiorKGOW/My-Guitar-Store/assets/93318917/072e1d66-a1f2-4895-b408-1be1af4ab765)

Appropriate AboutModal opens presenting more information about the clicked guitar
![Appropriate AboutModal opens presenting more information about the clicked guitar](https://github.com/LiorKGOW/My-Guitar-Store/assets/93318917/ecfd4208-f07c-474a-8ef7-e1f6b65139a6)


Screenshots before #35 was merged:

Added button in the Guitar Gallery
![Screenshot from Guitar Store ver 2](https://user-images.githubusercontent.com/93318917/198262243-49218f0b-6d11-4e0c-b7a2-bf616869a88c.png)

PF4 About Modal for a single Guitar
![Screenshot from Guitar Store ver 2 (1)](https://user-images.githubusercontent.com/93318917/198262324-ba6d6a89-327c-46b5-add6-f0c57dd513c1.png)
