### PR TITLE
Downgrading Webpack Back to Ver 4

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -84,7 +84,7 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  config.log_formatter = Logger::Formatter.new
 
   # Use a different logger for distributed setups.
   # require "syslog/logger"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-dom": "^16.14.0",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "turbolinks": "^5.2.0",
-    "webpack": "^5.74.0",
+    "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12",
     "webpack-merge": "^5.8.0"
   },


### PR DESCRIPTION
This PR solves the issue reported by @MariaAga regarding the change in the Webpack version
The application should run for you now (Hopefully :) )
Just run: `npm install` / `yarn install` before you run the server

Please update me in case it doesn't work 👍🏼 

PS: as suggested, I kept the webpack-dev-server version as it was to match the one of webpack
