### PR TITLE
Adding Resourceful Routes to Guitars Controller

### DIFF
--- a/app/controllers/guitars_controller.rb
+++ b/app/controllers/guitars_controller.rb
@@ -1,30 +1,15 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/MethodLength
-
 class GuitarsController < ApplicationController
   def index
-    render json: [
-      {
-        name: 'guitar1',
-        url: 'https://rukminim1.flixcart.com/image/416/416/acoustic-guitar/x/8/w/topaz-blue-signature-original-imaefec7uhypjdr9.jpeg?q=70',
-        price: '100',
-        description: 'blablabla 1'
-      },
-      {
-        name: 'guitar2',
-        url: 'https://shop.brianmayguitars.co.uk/user/special/content/Antique%20Cherry%20a.jpg',
-        price: '200',
-        description: 'blablabla 2'
-      },
-      {
-        name: 'guitar3',
-        url: 'https://cdn.mos.cms.futurecdn.net/Yh6r74b8CAj2jbdf2FAhq4-970-80.jpg.webp',
-        price: '300',
-        description: 'blablabla 3'
-      }
-    ]
+    render json: Guitar.all
   end
-end
 
-# rubocop:enable Metrics/MethodLength
+  def show; end
+
+  def new; end
+
+  def edit; end
+
+  def delete; end
+end

--- a/app/controllers/guitars_controller.rb
+++ b/app/controllers/guitars_controller.rb
@@ -11,5 +11,11 @@ class GuitarsController < ApplicationController
 
   def edit; end
 
+  def create; end
+
+  def update; end
+
   def delete; end
+
+  def destroy; end
 end

--- a/app/helpers/guitars_helper.rb
+++ b/app/helpers/guitars_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module GuitarsHelper
+end

--- a/app/models/guitar.rb
+++ b/app/models/guitar.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Guitar < ApplicationRecord
+end

--- a/app/views/guitars/delete.html.erb
+++ b/app/views/guitars/delete.html.erb
@@ -1,0 +1,1 @@
+<h1>Guitars#delete</h1>

--- a/app/views/guitars/edit.html.erb
+++ b/app/views/guitars/edit.html.erb
@@ -1,0 +1,1 @@
+<h1>Guitars#edit</h1>

--- a/app/views/guitars/index.html.erb
+++ b/app/views/guitars/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Guitars#index</h1>

--- a/app/views/guitars/new.html.erb
+++ b/app/views/guitars/new.html.erb
@@ -1,0 +1,1 @@
+<h1>Guitars#new</h1>

--- a/app/views/guitars/show.html.erb
+++ b/app/views/guitars/show.html.erb
@@ -1,0 +1,1 @@
+<h1>Guitars#show</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get 'guitars/index'
-  get 'guitars/show'
-  get 'guitars/new'
-  get 'guitars/edit'
-  get 'guitars/delete'
   root 'home#index'
   get '/guitars', to: 'guitars#index'
+
+  resources :guitars do
+    member do
+      get :delete
+    end
+  end
+
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  get 'guitars/index'
+  get 'guitars/show'
+  get 'guitars/new'
+  get 'guitars/edit'
+  get 'guitars/delete'
   root 'home#index'
   get '/guitars', to: 'guitars#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20230104141230_create_guitars.rb
+++ b/db/migrate/20230104141230_create_guitars.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateGuitars < ActiveRecord::Migration[6.1]
+  def change
+    create_table :guitars do |t|
+      t.string :name
+      t.string :url
+      t.integer :price
+      t.string :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2023_01_04_141230) do
+
+  create_table "guitars", force: :cascade do |t|
+    t.string "name"
+    t.string "url"
+    t.integer "price"
+    t.string "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #
@@ -6,3 +7,21 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+Guitar.destroy_all
+
+Guitar.create!([
+                 {
+                   name: 'guitar1',
+                   url: 'https://rukminim1.flixcart.com/image/416/416/acoustic-guitar/x/8/w/topaz-blue-signature-original-imaefec7uhypjdr9.jpeg?q=70',
+                   price: '100',
+                   description: 'blablabla 1'
+                 },
+                 {
+                   name: 'guitar2',
+                   url: 'https://shop.brianmayguitars.co.uk/user/special/content/Antique%20Cherry%20a.jpg',
+                   price: '200',
+                   description: 'blablabla 2'
+                 }
+               ])
+
+Rails.logger.debug { "Created #{Guitar.count} Guitars." }

--- a/test/controllers/guitars_controller_test.rb
+++ b/test/controllers/guitars_controller_test.rb
@@ -3,8 +3,28 @@
 require 'test_helper'
 
 class GuitarsControllerTest < ActionDispatch::IntegrationTest
-  test 'get index' do
+  test 'should get index' do
     get guitars_index_url
+    assert_response :success
+  end
+
+  test 'should get show' do
+    get guitars_show_url
+    assert_response :success
+  end
+
+  test 'should get new' do
+    get guitars_new_url
+    assert_response :success
+  end
+
+  test 'should get edit' do
+    get guitars_edit_url
+    assert_response :success
+  end
+
+  test 'should get delete' do
+    get guitars_delete_url
     assert_response :success
   end
 end

--- a/test/fixtures/guitars.yml
+++ b/test/fixtures/guitars.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  url: MyString
+  price: 1
+  description: MyString
+
+two:
+  name: MyString
+  url: MyString
+  price: 1
+  description: MyString

--- a/test/models/guitar_test.rb
+++ b/test/models/guitar_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GuitarTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Adding resourceful routes to Guitars controller, with the remaining CRUD operations that don't have a template
Removing the get routes that the resourceful routes have

This PR is Blocked by: https://github.com/LiorKGOW/My-Guitar-Store/pull/32 