### PR TITLE
Adding Guitars Update Action + Corresponding UI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,6 @@ require: rubocop-rails
 
 Style/Documentation:
   Enabled: false
+
+Metrics/AbcSize:
+  Max: 25 

--- a/app/controllers/guitars_controller.rb
+++ b/app/controllers/guitars_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class GuitarsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:update]
+
   def index
     render json: Guitar.all
   end
@@ -13,7 +15,18 @@ class GuitarsController < ApplicationController
 
   def create; end
 
-  def update; end
+  def update
+    # Find the Guitar in the DB with an 'id' of ${id}:
+    @guitar = Guitar.find(params[:id])
+
+    # Update the Guitar in the DB:
+    if @guitar.update({ name: params[:name], url: params[:url], price: params[:price],
+                        description: params[:description] })
+      render json: @guitar
+    else
+      render json: @guitar.errors, status: :unprocessable_entity
+    end
+  end
 
   def delete; end
 

--- a/app/javascript/components/GuitarGallery.js
+++ b/app/javascript/components/GuitarGallery.js
@@ -2,14 +2,14 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { Title, TitleSizes, Gallery, Spinner } from '@patternfly/react-core';
 import GuitarInfo from './GuitarInfo';
-import { guitarsUrl } from './constants';
-
-// Loading the data from the server:
+import { GUITARS_URL } from './constants';
 
 const GuitarGallery = () => {
+  // Loading the data from the server:
+
   const getGuitars = async () => {
     try {
-      const response = await axios.get(guitarsUrl);
+      const response = await axios.get(GUITARS_URL);
       if (response.data) {
         setGuitars(response.data);
       }
@@ -40,8 +40,16 @@ const GuitarGallery = () => {
         {guitars.length === 0 ? (
           <Spinner isSVG aria-label="Contents of the Guitar Gallery" aria-valuetext="Loading..." />
         ) : (
-          guitars.map(({ name, url, price, description }) => (
-            <GuitarInfo key={name} name={name} url={url} price={price} description={description} />
+          guitars.map(({ id, name, url, price, description }) => (
+            <GuitarInfo
+              key={id}
+              id={id}
+              name={name}
+              url={url}
+              price={price}
+              description={description}
+              getGuitars={getGuitars}
+            />
           ))
         )}
       </Gallery>

--- a/app/javascript/components/GuitarInfo.js
+++ b/app/javascript/components/GuitarInfo.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import axios from 'axios';
 import PropTypes from 'prop-types';
 import {
   GalleryItem,
@@ -7,10 +8,62 @@ import {
   Card,
   CardTitle,
   CardBody,
-  CardFooter
+  CardFooter,
+  Button,
+  Modal,
+  ModalVariant,
+  Form,
+  FormGroup,
+  TextInput
 } from '@patternfly/react-core';
+import { getGuitarUrlWithId } from './constants.js';
 
-const GuitarInfo = ({ name, url, price, description }) => {
+const GuitarInfo = ({ id, name, url, price, description, getGuitars }) => {
+  const [isFormModalOpen, setIsFormModalOpen] = useState(false);
+
+  const openFormModal = () => {
+    setIsFormModalOpen(true);
+  };
+
+  const closeFormModal = () => {
+    setIsFormModalOpen(false);
+  };
+
+  // Form Attributes useStates():
+  const [nameValue, setNameValue] = useState(name);
+  const [urlValue, setUrlValue] = useState(url);
+  const [priceValue, setPriceValue] = useState(price);
+  const [descriptionValue, setDescriptionValue] = useState(description);
+
+  const cancelEditOfGuitar = () => {
+    closeFormModal();
+
+    // Repopulate the fields of the form with the original guitar's attributes:
+    setNameValue(name);
+    setUrlValue(url);
+    setPriceValue(price);
+    setDescriptionValue(description);
+  };
+
+  const updateGuitar = async () => {
+    closeFormModal();
+
+    const updatedGuitarUrl = getGuitarUrlWithId(id);
+
+    try {
+      await axios.put(updatedGuitarUrl, {
+        name: nameValue,
+        url: urlValue,
+        price: priceValue,
+        description: descriptionValue
+      });
+      getGuitars();
+    } catch (error) {
+      console.log('Server have encountered an error:');
+      console.log(error);
+    }
+  };
+
   return (
     <GalleryItem>
       <Card id={name} isFlat>
@@ -20,19 +73,92 @@ const GuitarInfo = ({ name, url, price, description }) => {
           </GridItem>
           <GridItem>
             <CardTitle>{name}</CardTitle>
-            <CardBody>Price: {price}</CardBody>
-            <CardFooter>Description: {description}</CardFooter>
+            <CardBody>
+              Price: {price} <br />
+              Description: {description}
+            </CardBody>
+            <CardFooter>
+              <Button variant="secondary" onClick={openFormModal}>
+                Edit
+              </Button>
+            </CardFooter>
           </GridItem>
         </Grid>
       </Card>
+
+      {isFormModalOpen && (
+        <Modal
+          variant={ModalVariant.small}
+          title="Edit Guitar"
+          description="Change the fields you wish to change and then click 'Update'"
+          isOpen={isFormModalOpen}
+          onClose={cancelEditOfGuitar}
+          actions={[
+            <Button
+              key="update"
+              variant="primary"
+              form="modal-with-form-form"
+              onClick={updateGuitar}>
+              Update
+            </Button>,
+            <Button key="cancel" variant="link" onClick={cancelEditOfGuitar}>
+              Cancel
+            </Button>
+          ]}>
+          <Form id="modal-with-form-form">
+            <FormGroup label="Name" isRequired fieldId="modal-with-form-form-name">
+              <TextInput
+                isRequired
+                type="string"
+                id="modal-with-form-form-name"
+                name="modal-with-form-form-name"
+                value={nameValue}
+                onChange={setNameValue}
+              />
+            </FormGroup>
+            <FormGroup label="Url" isRequired fieldId="modal-with-form-form-url">
+              <TextInput
+                isRequired
+                type="url"
+                id="modal-with-form-form-url"
+                name="modal-with-form-form-url"
+                value={urlValue}
+                onChange={setUrlValue}
+              />
+            </FormGroup>
+            <FormGroup label="Price" isRequired fieldId="modal-with-form-form-price">
+              <TextInput
+                isRequired
+                type="number"
+                id="modal-with-form-form-price"
+                name="modal-with-form-form-price"
+                value={priceValue}
+                onChange={setPriceValue}
+              />
+            </FormGroup>
+            <FormGroup label="Description" isRequired fieldId="modal-with-form-form-description">
+              <TextInput
+                isRequired
+                type="string"
+                id="modal-with-form-form-description"
+                name="modal-with-form-form-description"
+                value={descriptionValue}
+                onChange={setDescriptionValue}
+              />
+            </FormGroup>
+          </Form>
+        </Modal>
+      )}
     </GalleryItem>
   );
 };
 GuitarInfo.propTypes = {
+  id: PropTypes.number.isRequired,
   name: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
-  price: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired
+  price: PropTypes.number.isRequired,
+  description: PropTypes.string.isRequired,
+  getGuitars: PropTypes.func.isRequired
 };
 
 export default GuitarInfo;

--- a/app/javascript/components/constants.js
+++ b/app/javascript/components/constants.js
@@ -1,1 +1,5 @@
-export const guitarsUrl = '/guitars';
+export const GUITARS_URL = '/guitars';
+
+export const getGuitarUrlWithId = (id) => {
+  return GUITARS_URL + `/${id}`;
+};

--- a/app/javascript/components/tests/GuitarGallery.test.js
+++ b/app/javascript/components/tests/GuitarGallery.test.js
@@ -3,15 +3,15 @@ import { waitFor, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import axios from 'axios';
 import GuitarGallery from '../GuitarGallery.js';
-import { guitarsUrl } from '../constants';
+import { GUITARS_URL } from '../constants';
 import { guitarData } from './fixtures';
 
-test("show loader when it's fetching data, then render Guitars", async () => {
+test('rendering the GuitarGallery component and asserting for test mock data to be in the page', async () => {
   await axios.get.mockResolvedValueOnce(guitarData);
-  const { unmount, getByText } = render(<GuitarGallery />);
+  const { unmount, getByText } = render(<GuitarGallery key={1} />);
 
   // check the correct url is called:
-  expect(axios.get).toHaveBeenCalledWith(guitarsUrl);
+  expect(axios.get).toHaveBeenCalledWith(GUITARS_URL);
   expect(axios.get).toHaveBeenCalledTimes(1);
 
   // ensure the title of the page is presented in the page:
@@ -21,12 +21,22 @@ test("show loader when it's fetching data, then render Guitars", async () => {
   const title = getByText(/Guitars For Sale:/);
   expect(title).toHaveTextContent('Guitars For Sale:');
 
-  // ensure some content of the page is presented in the page:
+  // ensure some content of the page is presented in the page (including name & price):
+  await waitFor(() => screen.getByText('guitar1_test'));
 
-  await waitFor(() => screen.getByText('Description: some description in guitar1_test'));
+  const element = getByText('guitar1_test');
+  expect(element).toHaveTextContent('guitar1_test');
+  expect(element).toBeInTheDocument();
 
-  expect(screen.getByText('Description: some description in guitar1_test')).toBeInTheDocument();
-  expect(screen.getByText('Description: some description in guitar2_test')).toBeInTheDocument();
+  expect(screen.getByText('guitar2_test')).toBeInTheDocument();
+
+  const elementContainingPrice = screen.getByText(/100/);
+  expect(elementContainingPrice).toBeInTheDocument();
+  expect(elementContainingPrice).toHaveTextContent(/Price/i);
+
+  const anotherElementContainingPrice = screen.getByText(/200/);
+  expect(anotherElementContainingPrice).toBeInTheDocument();
+  expect(anotherElementContainingPrice).toHaveTextContent(/Price/i);
 
   // unmnount the component from the DOM
   unmount();

--- a/app/javascript/components/tests/fixtures.js
+++ b/app/javascript/components/tests/fixtures.js
@@ -1,15 +1,17 @@
 export const guitarData = {
   data: [
     {
+      id: 1,
       name: 'guitar1_test',
       url: 'https://rukminim1.flixcart.com/image/416/416/acoustic-guitar/x/8/w/topaz-blue-signature-original-imaefec7uhypjdr9.jpeg?q=70',
-      price: '100',
+      price: 100,
       description: 'some description in guitar1_test'
     },
     {
+      id: 2,
       name: 'guitar2_test',
       url: 'https://shop.brianmayguitars.co.uk/user/special/content/Antique%20Cherry%20a.jpg',
-      price: '200',
+      price: 200,
       description: 'some description in guitar2_test'
     }
   ]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rails-app",
   "private": true,
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint --ext js,jsx,ts,tsx",
     "lint:fix": "eslint --fix",
     "test": "jest",
     "format": "prettier --write './**/*.{js,jsx,ts,tsx,css,md,json}' --config ./.prettierrc"


### PR DESCRIPTION
- [x] Fix broken test - GuitarGallery

Now users can update guitars from the UI :)
The DB & the Presented Gallery is Updated immediately after performing the changes.

Added an Edit button to each GuitarGalleryItem:
![Screenshot from 2023-01-11 17-08-37](https://user-images.githubusercontent.com/93318917/211841751-6382357b-1096-41df-90d3-7b547be7378b.png)

Clicking on the 'Edit' button would open this ModalForm with the attributes of the edited guitar:
![Screenshot from 2023-01-11 16-37-50](https://user-images.githubusercontent.com/93318917/211840450-cbf348a0-3caa-4030-97e2-ac9a9784104b.png)

The appropriate Guitar was updated in the gallery:
![Screenshot from 2023-01-11 17-10-41](https://user-images.githubusercontent.com/93318917/211842284-a9e99a95-e331-4aa7-9018-e2b375884c45.png)