### PR TITLE
Adding Guitars Create Action + Corresponding UI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,6 @@ require: rubocop-rails
 
 Style/Documentation:
   Enabled: false
+
+Metrics/AbcSize:
+  Max: 25 

--- a/app/controllers/guitars_controller.rb
+++ b/app/controllers/guitars_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class GuitarsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:create]
+
   def index
     render json: Guitar.all
   end
@@ -11,11 +13,37 @@ class GuitarsController < ApplicationController
 
   def edit; end
 
-  def create; end
+  def create
+    # Instantiate a new Guitar
+    @guitar = Guitar.new(guitar_params)
+
+    # Insert the new values inserted by the user to the instance variable of the guitar:
+    apply_guitar_attributes(params[:name], params[:url], params[:price], params[:description])
+
+    # Save the guitar to the DB
+    if @guitar.save
+      render json: @guitar
+    else
+      render json: @guitar.errors, status: :unprocessable_entity
+    end
+  end
 
   def update; end
 
   def delete; end
 
   def destroy; end
+
+  private
+
+  def guitar_params
+    params.require(:guitar).permit(:name, :url, :price, :description)
+  end
+
+  def apply_guitar_attributes(name, url, price, description)
+    @guitar.name = name
+    @guitar.url = url
+    @guitar.price = price
+    @guitar.description = description
+  end
 end

--- a/app/javascript/components/GuitarGallery.js
+++ b/app/javascript/components/GuitarGallery.js
@@ -2,14 +2,14 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { Title, TitleSizes, Gallery, Spinner } from '@patternfly/react-core';
 import GuitarInfo from './GuitarInfo';
-import { guitarsUrl } from './constants';
+import { GUITARS_URL } from './constants';
 
 // Loading the data from the server:
 
 const GuitarGallery = () => {
   const getGuitars = async () => {
     try {
-      const response = await axios.get(guitarsUrl);
+      const response = await axios.get(GUITARS_URL);
       if (response.data) {
         setGuitars(response.data);
       }
@@ -40,8 +40,15 @@ const GuitarGallery = () => {
         {guitars.length === 0 ? (
           <Spinner isSVG aria-label="Contents of the Guitar Gallery" aria-valuetext="Loading..." />
         ) : (
-          guitars.map(({ name, url, price, description }) => (
-            <GuitarInfo key={name} name={name} url={url} price={price} description={description} />
+          guitars.map(({ id, name, url, price, description }) => (
+            <GuitarInfo
+              key={id}
+              id={id}
+              name={name}
+              url={url}
+              price={price}
+              description={description}
+            />
           ))
         )}
       </Gallery>

--- a/app/javascript/components/GuitarInfo.js
+++ b/app/javascript/components/GuitarInfo.js
@@ -10,10 +10,10 @@ import {
   CardFooter
 } from '@patternfly/react-core';
 
-const GuitarInfo = ({ name, url, price, description }) => {
+const GuitarInfo = ({ id, name, url, price, description }) => {
   return (
     <GalleryItem>
-      <Card id={name} isFlat>
+      <Card id={id} isFlat>
         <Grid md={6}>
           <GridItem>
             <img className="Guitar-Image" src={url} alt="Guitar Image" />
@@ -29,9 +29,10 @@ const GuitarInfo = ({ name, url, price, description }) => {
   );
 };
 GuitarInfo.propTypes = {
+  id: PropTypes.number.isRequired,
   name: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
-  price: PropTypes.string.isRequired,
+  price: PropTypes.number.isRequired,
   description: PropTypes.string.isRequired
 };
 

--- a/app/javascript/components/MyGuitarStore.js
+++ b/app/javascript/components/MyGuitarStore.js
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { Button, Modal, ModalVariant, Form, FormGroup, TextInput } from '@patternfly/react-core';
+import GuitarGallery from './GuitarGallery';
+import { GUITARS_URL } from './constants.js';
+
+const MyGuitarStore = () => {
+  // Create Form:
+
+  const initialFormValues = {
+    name: '',
+    url: '',
+    price: '',
+    description: ''
+  };
+
+  const [isFormModalOpen, setIsFormModalOpen] = useState(false);
+
+  const openFormModal = () => {
+    setIsFormModalOpen(true);
+  };
+
+  const closeFormModal = () => {
+    setIsFormModalOpen(false);
+  };
+
+  // Form Attributes useStates():
+  const [nameValue, setNameValue] = useState(initialFormValues['name']);
+  const [urlValue, setUrlValue] = useState(initialFormValues['url']);
+  const [priceValue, setPriceValue] = useState(initialFormValues['price']);
+  const [descriptionValue, setDescriptionValue] = useState(initialFormValues['description']);
+
+  const emptyFormValues = () => {
+    setNameValue(initialFormValues['name']);
+    setUrlValue(initialFormValues['url']);
+    setPriceValue(initialFormValues['price']);
+    setDescriptionValue(initialFormValues['description']);
+  };
+
+  const cancelCreationOfGuitar = () => {
+    closeFormModal();
+    emptyFormValues();
+  };
+
+  const createGuitar = async () => {
+    closeFormModal();
+
+    try {
+      await axios.post(GUITARS_URL, {
+        name: nameValue,
+        url: urlValue,
+        price: priceValue,
+        description: descriptionValue
+      });
+    } catch (error) {
+      console.log('Server have encountered an error:');
+      console.log(error);
+    } finally {
+      emptyFormValues();
+    }
+  };
+
+  return (
+    <>
+      <GuitarGallery />
+      <br />
+      <Button variant="primary" onClick={openFormModal}>
+        Create a New Guitar
+      </Button>
+
+      <Modal
+        variant={ModalVariant.small}
+        title="Create a new Guitar"
+        description="Add the fields you wish to add, then click 'Create Guitar'"
+        isOpen={isFormModalOpen}
+        onClose={cancelCreationOfGuitar}
+        actions={[
+          <Button key="create" variant="primary" form="modal-with-form-form" onClick={createGuitar}>
+            Create Guitar
+          </Button>,
+          <Button key="cancel" variant="link" onClick={cancelCreationOfGuitar}>
+            Cancel
+          </Button>
+        ]}>
+        <Form id="modal-with-form-form">
+          <FormGroup label="Name" isRequired fieldId="modal-with-form-form-name">
+            <TextInput
+              isRequired
+              type="string"
+              id="modal-with-form-form-name"
+              name="modal-with-form-form-name"
+              value={nameValue}
+              onChange={setNameValue}
+            />
+          </FormGroup>
+          <FormGroup label="Url" isRequired fieldId="modal-with-form-form-url">
+            <TextInput
+              isRequired
+              type="url"
+              id="modal-with-form-form-url"
+              name="modal-with-form-form-url"
+              value={urlValue}
+              onChange={setUrlValue}
+            />
+          </FormGroup>
+          <FormGroup label="Price" isRequired fieldId="modal-with-form-form-price">
+            <TextInput
+              isRequired
+              type="number"
+              id="modal-with-form-form-price"
+              name="modal-with-form-form-price"
+              value={priceValue}
+              onChange={setPriceValue}
+            />
+          </FormGroup>
+          <FormGroup label="Description" isRequired fieldId="modal-with-form-form-description">
+            <TextInput
+              isRequired
+              type="string"
+              id="modal-with-form-form-description"
+              name="modal-with-form-form-description"
+              value={descriptionValue}
+              onChange={setDescriptionValue}
+            />
+          </FormGroup>
+        </Form>
+      </Modal>
+    </>
+  );
+};
+
+export default MyGuitarStore;

--- a/app/javascript/components/constants.js
+++ b/app/javascript/components/constants.js
@@ -1,1 +1,5 @@
-export const guitarsUrl = '/guitars';
+export const GUITARS_URL = '/guitars';
+
+export const getGuitarUrlWithId = (id) => {
+  return GUITARS_URL + `/${id}`;
+};

--- a/app/javascript/packs/hello_react.jsx
+++ b/app/javascript/packs/hello_react.jsx
@@ -3,9 +3,9 @@
 // of the page.
 import React from 'react';
 import ReactDOM from 'react-dom';
-import GuitarGallery from '../components/GuitarGallery';
+import MyGuitarStore from '../components/MyGuitarStore';
 import './fonts.css';
 
 document.addEventListener('DOMContentLoaded', () => {
-  ReactDOM.render(<GuitarGallery />, document.body.appendChild(document.createElement('div')));
+  ReactDOM.render(<MyGuitarStore />, document.body.appendChild(document.createElement('div')));
 });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rails-app",
   "private": true,
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint --ext js,jsx,ts,tsx",
     "lint:fix": "eslint --fix",
     "test": "jest",
     "format": "prettier --write './**/*.{js,jsx,ts,tsx,css,md,json}' --config ./.prettierrc"


### PR DESCRIPTION
- [ ] Fix broken test - GuitarGallery

Now users can create guitars from the UI
They will need to refresh the page in order to see their changes, but the DB is updated

Added a 'Create a New Guitar' button:
![Screenshot from 2023-01-12 11-10-42](https://user-images.githubusercontent.com/93318917/212032257-fed107b7-49c2-4654-8e22-b2cb2bde119c.png)

Empty Guitar creation form is presented when the 'Create a New Guitar' button is pressed
![New Form](https://user-images.githubusercontent.com/93318917/212030745-366b854f-b3db-4e6d-91a4-158ab2ae04d5.png)

For the following data:
![Screenshot from 2023-01-12 11-14-50](https://user-images.githubusercontent.com/93318917/212031053-3d0f54bd-75c3-4192-b39d-2b8d9cd265fb.png)

A new Guitar is created in the DB: (output from the server)
![Screenshot from 2023-01-12 11-25-41](https://user-images.githubusercontent.com/93318917/212032390-8ad29fb5-aa8e-4bda-94c1-b5249edb602e.png)

From the Rails Console:
![Screenshot from 2023-01-12 11-28-33](https://user-images.githubusercontent.com/93318917/212032607-817e5548-f9e7-48d6-8a37-86d00e8daf22.png)

And is presented in the Guitar Gallery:
![Screenshot from 2023-01-12 11-26-59](https://user-images.githubusercontent.com/93318917/212032891-1ea4d7ca-b422-495d-b6db-911e529fe301.png)
