### PR TITLE
Adding Guitars Delete Action + Corresponding UI

### DIFF
--- a/app/controllers/guitars_controller.rb
+++ b/app/controllers/guitars_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class GuitarsController < ApplicationController
-  skip_before_action :verify_authenticity_token, only: [:update]
+  skip_before_action :verify_authenticity_token, only: [:update, :destroy]
 
   def index
     render json: Guitar.all
@@ -30,5 +30,9 @@ class GuitarsController < ApplicationController
 
   def delete; end
 
-  def destroy; end
+  def destroy
+    # Find the Guitar in the DB with the recieved id:
+    @guitar = Guitar.find(params[:id])
+    @guitar.destroy
+  end
 end

--- a/app/javascript/components/GuitarInfo.js
+++ b/app/javascript/components/GuitarInfo.js
@@ -20,12 +20,16 @@ import {
   TextList,
   TextListItem
 } from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import { getGuitarUrlWithId } from './constants.js';
 import { logoUrl } from './constants.js';
 
 const GuitarInfo = ({ id, name, url, price, description, getGuitars }) => {
-  // About Modal
   const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
+  const [isFormModalOpen, setIsFormModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  // Read Functions:
 
   const openAboutModal = () => {
     setIsAboutModalOpen(true);
@@ -35,8 +39,7 @@ const GuitarInfo = ({ id, name, url, price, description, getGuitars }) => {
     setIsAboutModalOpen(false);
   };
 
-  // Form Modal
-  const [isFormModalOpen, setIsFormModalOpen] = useState(false);
+  // Update Funcitons:
 
   const openFormModal = () => {
     setIsFormModalOpen(true);
@@ -81,14 +84,41 @@ const GuitarInfo = ({ id, name, url, price, description, getGuitars }) => {
     }
   };
 
+  // Delete Functions:
+
+  const openDeleteModal = () => {
+    setIsDeleteModalOpen(true);
+  };
+
+  const closeDeleteModal = () => {
+    setIsDeleteModalOpen(false);
+  };
+
+  const destroyGuitar = async () => {
+    closeDeleteModal();
+
+    const updatedGuitarToDeleteUrl = getGuitarUrlWithId(id);
+
+    try {
+      await axios.delete(updatedGuitarToDeleteUrl);
+      getGuitars();
+    } catch (error) {
+      console.log('Server have encountered an error:');
+      console.log(error);
+    }
+  };
+
   return (
     <GalleryItem>
-      <Card id={name} isFlat>
+      <Card id={id} isFlat>
         <Grid md={6}>
           <GridItem>
             <img className="Guitar-Image" src={url} alt="Guitar Image" />
           </GridItem>
           <GridItem>
+            <Button variant="plain" aria-label="Action" onClick={openDeleteModal}>
+              <TimesIcon />
+            </Button>
             <CardTitle>{name}</CardTitle>
             <CardBody>Price: {price}</CardBody>
             <CardFooter>
@@ -102,6 +132,28 @@ const GuitarInfo = ({ id, name, url, price, description, getGuitars }) => {
           </GridItem>
         </Grid>
       </Card>
+
+      {isAboutModalOpen && (
+        <AboutModal
+          isOpen={isAboutModalOpen}
+          onClose={closeAboutModal}
+          trademark="Trademark and stuff"
+          brandImageSrc={logoUrl}
+          brandImageAlt="Guitar Image"
+          productName={name}
+          backgroundImageSrc={url}>
+          <TextContent>
+            <TextList component="dl">
+              <TextListItem component="dt">Name: </TextListItem>
+              <TextListItem component="dd">{name}</TextListItem>
+              <TextListItem component="dt">Description: </TextListItem>
+              <TextListItem component="dd">{description}</TextListItem>
+              <TextListItem component="dt">Price: </TextListItem>
+              <TextListItem component="dd">{price}</TextListItem>
+            </TextList>
+          </TextContent>
+        </AboutModal>
+      )}
 
       {isFormModalOpen && (
         <Modal
@@ -167,26 +219,23 @@ const GuitarInfo = ({ id, name, url, price, description, getGuitars }) => {
         </Modal>
       )}
 
-      {isAboutModalOpen && (
-        <AboutModal
-          isOpen={isAboutModalOpen}
-          onClose={closeAboutModal}
-          trademark="Trademark and stuff"
-          brandImageSrc={logoUrl}
-          brandImageAlt="Guitar Image"
-          productName={name}
-          backgroundImageSrc={url}>
-          <TextContent>
-            <TextList component="dl">
-              <TextListItem component="dt">Name: </TextListItem>
-              <TextListItem component="dd">{name}</TextListItem>
-              <TextListItem component="dt">Description: </TextListItem>
-              <TextListItem component="dd">{description}</TextListItem>
-              <TextListItem component="dt">Price: </TextListItem>
-              <TextListItem component="dd">{price}</TextListItem>
-            </TextList>
-          </TextContent>
-        </AboutModal>
+      {isDeleteModalOpen && (
+        <Modal
+          variant={ModalVariant.small}
+          title="Delete Confirmation"
+          isOpen={isDeleteModalOpen}
+          onClose={closeDeleteModal}
+          actions={[
+            <Button key="confirm" variant="danger" onClick={destroyGuitar}>
+              Delete Guitar
+            </Button>,
+            <Button key="cancel" variant="secondary" isDanger onClick={closeDeleteModal}>
+              Cancel
+            </Button>
+          ]}>
+          {`Are you sure you want to delete the guitar "${name}"?
+          This action cannot be undone`}
+        </Modal>
       )}
     </GalleryItem>
   );


### PR DESCRIPTION
Now users can delete guitars from the UI
They will need to refresh the page in order to see their changes, but the DB is updated

TODO:
- [ ] Fix broken test - GuitarGallery.test.js

Added an 'X' button in each GalleryItem (+ status of the Gallery before the deletion of "LikeSea" guitar):
![Added an 'X' button in each GalleryItem (+ status of the Gallery before the deletion of "LikeSea" guitar)](https://github.com/LiorKGOW/My-Guitar-Store/assets/93318917/88637fa6-2621-465b-9f18-198129816ed4)

Clicking the 'X' button opens a deleteModal (for instance here for the guitar with a name of "LikeSea"):
![Clicking on the button opens a deleteModal (delete action)](https://github.com/LiorKGOW/My-Guitar-Store/assets/93318917/367aa322-770f-41d3-9a27-7b3eaae80828)

DB before delete of 28, using rails console:
![DB before delete of 28, using rails console](https://github.com/LiorKGOW/My-Guitar-Store/assets/93318917/3baffc3a-dcc8-4f0f-9f10-215d1c400c2b)

Server output after confirming the deletion of "LikeSea":
![Server output after confirming the deletion](https://github.com/LiorKGOW/My-Guitar-Store/assets/93318917/9e72c6cf-d70d-49a2-98dd-4ad9a06b8697)

Gallery after "LikeSea" was deleted from the DB:
![Gallery after "LikeSea" was deleted from the DB](https://github.com/LiorKGOW/My-Guitar-Store/assets/93318917/2cc51985-990b-4fed-8d27-acf0b0bae964)

Search fails after trying to find guitar with id of 28 (corresponding to the guitar with the name "LikeSea") in the DB using rails console:
![Search fails after trying to find guitar with id of 28 (corresponding to the guitar with the name "LikeSea") in the DB using rails console](https://github.com/LiorKGOW/My-Guitar-Store/assets/93318917/cc0cf07e-3c37-418d-a747-2d6549777554)
